### PR TITLE
Use temporal unescape fork until library is updated to work with Dart…

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,14 +2,17 @@ name: flutter_news
 description: A Hacker News client in flutter
 
 dependencies:
-  #flutter:
-  #  sdk: flutter
+  flutter:
+    sdk: flutter
   url_launcher: '^0.4.0'
   timeago: '^1.0.0'
   shared_preferences:
   intl: '>=0.14.0 <0.15.0'
   intl_translation: '>=0.14.0 <0.15.0'
-  html_unescape: "^0.1.4"
+  html_unescape:
+    git:
+      url: git://github.com/andresaraujo/html_unescape.git
+      ref: patch-1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
… 1.24+

This is temporal until https://github.com/filiph/html_unescape/pull/1 lands in pub

cc @jgroman 